### PR TITLE
Disable USB tethering by default

### DIFF
--- a/usb-tethering.conf
+++ b/usb-tethering.conf
@@ -1,5 +1,5 @@
 # upstart service file for usb-tethering
 
-start on startup
+manual
 
 exec /bin/bash /usr/bin/usb-tethering


### PR DESCRIPTION
Early in the Xenial cycle, we enabled USB tethering out of the box to facilitate debugging (and porting). As the cycle draws to a close, we should disable it. I'll also be making a PR on halium-install so that the script will re-enable tethering.