### PR TITLE
[xenial] Set netmask and create dhcpcd4.leases

### DIFF
--- a/usb-tethering
+++ b/usb-tethering
@@ -60,8 +60,9 @@ ip_setup() {
 
 dhcpd_start() {
 	INTERFACES="$USB_IFACE"
-	/usr/sbin/dhcpd -4 -q -cf /etc/hybris-usb/dhcpd.conf -pf /run/hybris-usb/dhcpd4.pid -lf /run/hybris-usb/dhcpd4.lease
-
+	mkdir -p /run/hybris-usb
+	touch /run/hybris-usb/dhcpd4.leases
+	/usr/sbin/dhcpd -4 -q -cf /etc/hybris-usb/dhcpd.conf -pf /run/hybris-usb/dhcpd4.pid -lf /run/hybris-usb/dhcpd4.leases
 }
 
 usb_setup

--- a/usb-tethering
+++ b/usb-tethering
@@ -41,11 +41,11 @@ usb_info() {
 
 ip_setup() {
     if [ -n "$USB_IFACE" ]; then
-        ifconfig $USB_IFACE $LOCAL_IP
+        ifconfig $USB_IFACE $LOCAL_IP netmask 255.255.255.0
         return
     fi
     
-    ifconfig rndis0 $LOCAL_IP && USB_IFACE=rndis0
+    ifconfig rndis0 $LOCAL_IP netmask 255.255.255.0 && USB_IFACE=rndis0
     if [ -z "$USB_IFACE" ]; then
         ifconfig usb0 $LOCAL_IP && USB_IFACE=usb0
     fi


### PR DESCRIPTION
Clone of #2 for xenial branch

As stated in dhcpcd.leases man page, that database is required to be present before dhcpcd will start. It seems some dhcpcd versions did not enforce this requirement, but the one found in xenial
will refuse to start otherwise.

This PR fixes auto-assigning IP address for clients on usb-tethering network.